### PR TITLE
Confstore

### DIFF
--- a/long_test.go
+++ b/long_test.go
@@ -51,7 +51,7 @@ func helperTestNewRingBuilder(t *testing.T, zones int32) {
 		for server := int32(0); server < 50; server++ {
 			for device := int32(0); device < 2; device++ {
 				nodeID++
-				b.AddNode(true, capacity, []string{fmt.Sprintf("server%d", server), fmt.Sprintf("zone%d", zone)}, nil, "")
+				b.AddNode(true, capacity, []string{fmt.Sprintf("server%d", server), fmt.Sprintf("zone%d", zone)}, nil, "", []byte("Conf"))
 				//capacity++
 				//if capacity > 100 {
 				//	capacity = 1

--- a/node.go
+++ b/node.go
@@ -43,6 +43,8 @@ type Node interface {
 	// Meta is additional information for the node; not defined or used by the
 	// builder or ring directly.
 	Meta() string
+	// Conf contains the raw config bytes for this node.
+	Conf() []byte
 }
 
 // BuilderNode extends Node to allow for updating attributes. A Ring needs
@@ -55,6 +57,7 @@ type BuilderNode interface {
 	SetTier(level int, value string)
 	SetAddress(index int, value string)
 	SetMeta(value string)
+	SetConf(conf []byte)
 }
 
 type node struct {
@@ -67,6 +70,7 @@ type node struct {
 	tierIndexes []int32
 	addresses   []string
 	meta        string
+	conf        []byte
 }
 
 func newNode(b *tierBase, others []*node) *node {
@@ -137,6 +141,10 @@ func (n *node) Meta() string {
 	return n.meta
 }
 
+func (n *node) Conf() []byte {
+	return n.conf
+}
+
 func (n *node) SetActive(value bool) {
 	n.inactive = !value
 }
@@ -185,6 +193,10 @@ func (n *node) SetAddress(index int, value string) {
 
 func (n *node) SetMeta(value string) {
 	n.meta = value
+}
+
+func (n *node) SetConf(conf []byte) {
+	n.conf = conf
 }
 
 type NodeSlice []Node

--- a/node_test.go
+++ b/node_test.go
@@ -1,6 +1,7 @@
 package ring
 
 import "testing"
+import "bytes"
 
 type testSource struct {
 	// The repeat part will cause an id == 0 when starting with repeat = false
@@ -158,6 +159,13 @@ func TestNodeSimply(t *testing.T) {
 	}
 	n.SetMeta("meta value")
 	if n.Meta() != "meta value" {
+		t.Fatal("")
+	}
+	if !bytes.Equal(n.Conf(), []byte("")) {
+		t.Fatal("")
+	}
+	n.SetConf([]byte("confobj"))
+	if !bytes.Equal(n.Conf(), []byte("confobj")) {
 		t.Fatal("")
 	}
 }

--- a/rebalancer_test.go
+++ b/rebalancer_test.go
@@ -11,7 +11,7 @@ func TestRebalancerBasic(t *testing.T) {
 	b := NewBuilder()
 	b.SetReplicaCount(3)
 	for i := 0; i < 128; i++ {
-		b.AddNode(true, 1, nil, nil, "")
+		b.AddNode(true, 1, nil, nil, "", []byte("Conf"))
 	}
 	b.resizeIfNeeded()
 	rb := newRebalancer(b)
@@ -36,7 +36,7 @@ func TestRebalancerTier0(t *testing.T) {
 	b := NewBuilder()
 	b.SetReplicaCount(4)
 	for i := 0; i < 128; i++ {
-		b.AddNode(true, 1, []string{fmt.Sprintf("tier%d", i%16)}, nil, "")
+		b.AddNode(true, 1, []string{fmt.Sprintf("tier%d", i%16)}, nil, "", []byte("Conf"))
 	}
 	b.resizeIfNeeded()
 	rb := newRebalancer(b)
@@ -76,9 +76,9 @@ func TestRebalancerTier0b(t *testing.T) {
 	b := NewBuilder()
 	b.SetReplicaCount(4)
 	for i := 0; i < 127; i++ {
-		b.AddNode(true, 1, []string{fmt.Sprintf("tier%d", i%16)}, nil, "")
+		b.AddNode(true, 1, []string{fmt.Sprintf("tier%d", i%16)}, nil, "", []byte("Conf"))
 	}
-	b.AddNode(true, 1, []string{"tier0"}, nil, "")
+	b.AddNode(true, 1, []string{"tier0"}, nil, "", []byte("Conf"))
 	b.resizeIfNeeded()
 	rb := newRebalancer(b)
 	rb.rebalance()
@@ -127,10 +127,10 @@ func TestRebalancerTier0c(t *testing.T) {
 	b := NewBuilder()
 	b.SetReplicaCount(4)
 	for i := 0; i < 96; i++ {
-		b.AddNode(true, 1, []string{fmt.Sprintf("tier%d", i%16)}, nil, "")
+		b.AddNode(true, 1, []string{fmt.Sprintf("tier%d", i%16)}, nil, "", []byte("Conf"))
 	}
 	for i := 0; i < 32; i++ {
-		b.AddNode(true, 1, []string{"tier0"}, nil, "")
+		b.AddNode(true, 1, []string{"tier0"}, nil, "", []byte("Conf"))
 	}
 	b.resizeIfNeeded()
 	rb := newRebalancer(b)
@@ -192,7 +192,7 @@ func TestRebalancerTier1(t *testing.T) {
 	b := NewBuilder()
 	b.SetReplicaCount(4)
 	for i := 0; i < 128; i++ {
-		b.AddNode(true, 1, []string{fmt.Sprintf("tier0-%d", i%32), fmt.Sprintf("tier1-%d", i%16)}, nil, "")
+		b.AddNode(true, 1, []string{fmt.Sprintf("tier0-%d", i%32), fmt.Sprintf("tier1-%d", i%16)}, nil, "", []byte("Conf"))
 	}
 	b.resizeIfNeeded()
 	rb := newRebalancer(b)
@@ -246,10 +246,10 @@ func TestRebalancerTier1b(t *testing.T) {
 	b := NewBuilder()
 	b.SetReplicaCount(4)
 	for i := 0; i < 96; i++ {
-		b.AddNode(true, 1, []string{fmt.Sprintf("tier0-%d", i%32), fmt.Sprintf("tier1-%d", i%16)}, nil, "")
+		b.AddNode(true, 1, []string{fmt.Sprintf("tier0-%d", i%32), fmt.Sprintf("tier1-%d", i%16)}, nil, "", []byte("Conf"))
 	}
 	for i := 0; i < 32; i++ {
-		b.AddNode(true, 1, []string{"tier0-0", "tier1-0"}, nil, "")
+		b.AddNode(true, 1, []string{"tier0-0", "tier1-0"}, nil, "", []byte("Conf"))
 	}
 	b.resizeIfNeeded()
 	rb := newRebalancer(b)

--- a/ring/main.go
+++ b/ring/main.go
@@ -27,7 +27,7 @@ func mainEntry(args []string) error {
 	var r ring.Ring
 	var b *ring.Builder
 	var err error
-	if len(args) < 2 {
+	if len(args) < 2 || (len(args) > 1 && args[1] == "help") {
 		return helpCmd(args)
 	}
 	if len(args) > 2 && args[2] == "create" {
@@ -79,6 +79,8 @@ func mainEntry(args []string) error {
 			return err
 		}
 		return persist(r, b, args[1])
+	case "print-config":
+		return printConfigCmd(r, b)
 	}
 	return fmt.Errorf("unknown command: %#v", args[2])
 }
@@ -116,6 +118,9 @@ func helpCmd(args []string) error {
 %[1]s <file> tier
     Lists the tiers in the ring or builder file.
 
+%[1]s <file> print-config
+    Display's the current config in the provided ring or builder file.
+
 %[1]s <ring-file> partition <value>
     Lists information about the given partition's node assignments.
 
@@ -139,6 +144,9 @@ func helpCmd(args []string) error {
             the number of minutes to wait before reassigning a given replica of
             a partition. This is to give time for actual data to rebalance in
             the system before changing where it is assigned again.
+        configfile=<value>
+            The <value> is the path to a json config file that will be byte encoded
+            and stored as the global conf.
 
 %[1]s <builder-file> add [<name>=<value>] ...
     Adds a new node to the builder. Available attributes:
@@ -284,6 +292,7 @@ func nodeCmd(r ring.Ring, b *ring.Builder, args []string, full bool) (changed bo
 				[]string{"Tiers:", strings.Join(n.Tiers(), "\n")},
 				[]string{"Addresses:", strings.Join(n.Addresses(), "\n")},
 				[]string{"Meta:", n.Meta()},
+				[]string{"Conf:", string(n.Conf())},
 			}
 			fmt.Print(brimtext.Align(report, nil))
 		}
@@ -406,18 +415,29 @@ func createCmd(filename string, args []string) error {
 	pointsAllowed := 1
 	maxPartitionBitCount := 23
 	moveWait := 60
+	var conf []byte
 	var err error
 	for _, arg := range args {
-		switch arg {
+		sarg := strings.SplitN(arg, "=", 2)
+		if len(sarg) != 2 {
+			return fmt.Errorf(`invalid expression %#v; needs "="`, arg)
+		}
+		if sarg[0] == "" {
+			return fmt.Errorf(`invalid expression %#v; nothing was left of "="`, arg)
+		}
+		if sarg[1] == "" {
+			return fmt.Errorf(`invalid expression %#v; nothing was right of "="`, arg)
+		}
+		switch sarg[0] {
 		case "replicas":
-			if replicaCount, err = strconv.Atoi(arg); err != nil {
+			if replicaCount, err = strconv.Atoi(sarg[1]); err != nil {
 				return err
 			}
 			if replicaCount < 1 {
 				replicaCount = 1
 			}
 		case "points-allowed":
-			if pointsAllowed, err = strconv.Atoi(arg); err != nil {
+			if pointsAllowed, err = strconv.Atoi(sarg[1]); err != nil {
 				return err
 			}
 			if pointsAllowed < 0 {
@@ -426,7 +446,7 @@ func createCmd(filename string, args []string) error {
 				pointsAllowed = 255
 			}
 		case "max-partition-bits":
-			if maxPartitionBitCount, err = strconv.Atoi(arg); err != nil {
+			if maxPartitionBitCount, err = strconv.Atoi(sarg[1]); err != nil {
 				return err
 			}
 			if maxPartitionBitCount < 1 {
@@ -435,7 +455,7 @@ func createCmd(filename string, args []string) error {
 				maxPartitionBitCount = 64
 			}
 		case "move-wait":
-			if moveWait, err = strconv.Atoi(arg); err != nil {
+			if moveWait, err = strconv.Atoi(sarg[1]); err != nil {
 				return err
 			}
 			if moveWait < 0 {
@@ -443,6 +463,13 @@ func createCmd(filename string, args []string) error {
 			} else if moveWait > math.MaxUint16 {
 				moveWait = math.MaxUint16
 			}
+		case "configfile":
+			conf, err = ioutil.ReadFile(sarg[1])
+			if err != nil {
+				return fmt.Errorf("Error reading config file: %v", err)
+			}
+		default:
+			return fmt.Errorf("Invalid arg: '%s' in create cmd", arg)
 		}
 	}
 	if _, err = os.Stat(filename); err == nil {
@@ -456,6 +483,7 @@ func createCmd(filename string, args []string) error {
 		return err
 	}
 	b := ring.NewBuilder()
+	b.SetConf(conf)
 	b.SetReplicaCount(replicaCount)
 	b.SetPointsAllowed(byte(pointsAllowed))
 	b.SetMaxPartitionBitCount(uint16(maxPartitionBitCount))
@@ -477,6 +505,7 @@ func addOrSetCmd(r ring.Ring, b *ring.Builder, args []string, n ring.BuilderNode
 	capacity := uint32(1)
 	var tiers []string
 	var addresses []string
+	var conf []byte
 	meta := ""
 	for _, arg := range args {
 		sarg := strings.SplitN(arg, "=", 2)
@@ -522,6 +551,12 @@ func addOrSetCmd(r ring.Ring, b *ring.Builder, args []string, n ring.BuilderNode
 			if n != nil {
 				n.SetMeta(meta)
 			}
+		case "configfile":
+			var err error
+			conf, err = ioutil.ReadFile(sarg[1])
+			if err != nil {
+				return fmt.Errorf("Error reading config file: %v", err)
+			}
 		default:
 			if strings.HasPrefix(sarg[0], "tier") {
 				level, err := strconv.Atoi(sarg[0][4:])
@@ -561,7 +596,7 @@ func addOrSetCmd(r ring.Ring, b *ring.Builder, args []string, n ring.BuilderNode
 		}
 	}
 	if n == nil {
-		n = b.AddNode(active, capacity, tiers, addresses, meta)
+		n = b.AddNode(active, capacity, tiers, addresses, meta, conf)
 		report := [][]string{
 			[]string{"ID:", fmt.Sprintf("%016x", n.ID())},
 			[]string{"Active:", fmt.Sprintf("%v", n.Active())},
@@ -569,6 +604,7 @@ func addOrSetCmd(r ring.Ring, b *ring.Builder, args []string, n ring.BuilderNode
 			[]string{"Tiers:", strings.Join(n.Tiers(), "\n")},
 			[]string{"Addresses:", strings.Join(n.Addresses(), "\n")},
 			[]string{"Meta:", n.Meta()},
+			[]string{"Conf:", fmt.Sprintf("%s", n.Conf())},
 		}
 		fmt.Print(brimtext.Align(report, nil))
 	}
@@ -619,6 +655,15 @@ func pretendElapsedCmd(r ring.Ring, b *ring.Builder, args []string) error {
 		return fmt.Errorf("cannot pretend to elapse more than %d minutes", math.MaxUint16)
 	}
 	b.PretendElapsed(uint16(m))
+	return nil
+}
+
+func printConfigCmd(r ring.Ring, b *ring.Builder) error {
+	if b == nil {
+		fmt.Printf(string(r.Conf()))
+		return nil
+	}
+	fmt.Printf(string(b.Conf()))
 	return nil
 }
 

--- a/ring/main.go
+++ b/ring/main.go
@@ -168,6 +168,9 @@ func helpCmd(args []string) error {
             The [value] can be any string and is not used directly by the
             builder or ring. It can be used for notes about the node if
             desired, such as the model or serial number.
+        configfile=<value>
+            The <value> is the path to a json config file that will be byte encoded
+            and stored in this nodes conf field.
 
 %[1]s <builder-file> remove id=<value>
     Removes the specified node from the builder. Often it's quicker to just set
@@ -557,6 +560,9 @@ func addOrSetCmd(r ring.Ring, b *ring.Builder, args []string, n ring.BuilderNode
 			if err != nil {
 				return fmt.Errorf("Error reading config file: %v", err)
 			}
+			if n != nil {
+				n.SetConf(conf)
+			}
 		default:
 			if strings.HasPrefix(sarg[0], "tier") {
 				level, err := strconv.Atoi(sarg[0][4:])
@@ -592,6 +598,8 @@ func addOrSetCmd(r ring.Ring, b *ring.Builder, args []string, n ring.BuilderNode
 				if n != nil {
 					n.SetAddress(index, addresses[index])
 				}
+			} else {
+				return fmt.Errorf("Invalid arg '%s' in set.", sarg[0])
 			}
 		}
 	}

--- a/ring_test.go
+++ b/ring_test.go
@@ -2,7 +2,6 @@ package ring
 
 import (
 	"bytes"
-	"math"
 	"testing"
 )
 
@@ -13,26 +12,20 @@ func TestRingVersion(t *testing.T) {
 	}
 }
 
-func TestRingGlobalConf(t *testing.T) {
+func TestRingConf(t *testing.T) {
 	confbytes := []byte("three shall be the number thou shalt count")
-	v := (&ring{globalconf: confbytes}).GlobalConf()
+	v := (&ring{conf: confbytes}).Conf()
 	if !bytes.Equal(v, confbytes) {
-		t.Fatalf("GlobalConf() gave %s instead of %s", v, confbytes)
+		t.Fatalf("Conf() gave %s instead of %s", v, confbytes)
 	}
 }
 
-func TestRingSetGlobalConf(t *testing.T) {
+func TestRingSetConf(t *testing.T) {
 	confbytes := []byte("three shall be the number thou shalt count")
-	err := (&ring{globalconf: []byte("")}).SetGlobalConf(confbytes)
+	err := (&ring{conf: []byte("")}).SetConf(confbytes)
 	if err != nil {
-		t.Fatalf("SetGlobalConf():", err)
+		t.Fatalf("SetConf():", err)
 	}
-	toolarge := make([]byte, math.MaxInt32+1)
-	err = (&ring{globalconf: []byte("")}).SetGlobalConf(toolarge)
-	if err != ErrConfigTooLarge {
-		t.Fatalf("SetGlobalConf(): %+v", err)
-	}
-
 }
 
 func TestRingPartitionBitCount(t *testing.T) {
@@ -126,13 +119,13 @@ func TestRingResponsibleIDs(t *testing.T) {
 func TestRingPersistence(t *testing.T) {
 	b := NewBuilder()
 	b.SetReplicaCount(3)
-	b.AddNode(true, 1, []string{"server1", "zone1"}, []string{"1.2.3.4:56789"}, "Meta One")
-	b.AddNode(true, 1, []string{"server2", "zone1"}, []string{"1.2.3.5:56789", "1.2.3.5:9876"}, "Meta Four")
-	b.AddNode(false, 0, []string{"server3", "zone1"}, []string{"1.2.3.6:56789"}, "Meta Three")
+	b.AddNode(true, 1, []string{"server1", "zone1"}, []string{"1.2.3.4:56789"}, "Meta One", []byte("Conf"))
+	b.AddNode(true, 1, []string{"server2", "zone1"}, []string{"1.2.3.5:56789", "1.2.3.5:9876"}, "Meta Four", []byte("Conf"))
+	b.AddNode(false, 0, []string{"server3", "zone1"}, []string{"1.2.3.6:56789"}, "Meta Three", []byte("Conf"))
 	r := b.Ring().(*ring)
 	buf := bytes.NewBuffer(make([]byte, 0, 65536))
 	confbytes := []byte("three shall be the number thou shalt count")
-	err := r.SetGlobalConf(confbytes)
+	err := r.SetConf(confbytes)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -148,8 +141,8 @@ func TestRingPersistence(t *testing.T) {
 	if r2.version != r.version {
 		t.Fatalf("%v != %v", r2.version, r.version)
 	}
-	if !bytes.Equal(r2.globalconf, r.globalconf) {
-		t.Fatalf("%v != %v", r2.globalconf, r.globalconf)
+	if !bytes.Equal(r2.conf, r.conf) {
+		t.Fatalf("%v != %v", r2.conf, r.conf)
 	}
 	if len(r2.nodes) != len(r.nodes) {
 		t.Fatalf("%v != %v", len(r2.nodes), len(r.nodes))
@@ -179,6 +172,9 @@ func TestRingPersistence(t *testing.T) {
 		}
 		if r2.nodes[i].meta != r.nodes[i].meta {
 			t.Fatalf("%v != %v", r2.nodes[i].meta, r.nodes[i].meta)
+		}
+		if !bytes.Equal(r2.nodes[i].conf, r.nodes[i].conf) {
+			t.Fatalf("%v != %v", r2.nodes[i].conf, r.nodes[i].conf)
 		}
 	}
 	if r2.partitionBitCount != r.partitionBitCount {

--- a/tcp_msg_ring_test.go
+++ b/tcp_msg_ring_test.go
@@ -26,8 +26,8 @@ func newRingConn(conn net.Conn) *ringConn {
 func newTestRing() (Ring, Node, Node) {
 	b := NewBuilder()
 	b.SetReplicaCount(3)
-	nA := b.AddNode(true, 1, nil, []string{"127.0.0.1:9999"}, "")
-	nB := b.AddNode(true, 1, nil, []string{"127.0.0.1:8888"}, "")
+	nA := b.AddNode(true, 1, nil, []string{"127.0.0.1:9999"}, "", []byte("Conf"))
+	nB := b.AddNode(true, 1, nil, []string{"127.0.0.1:8888"}, "", []byte("Conf"))
 	r := b.Ring()
 	r.SetLocalNode(nA.ID())
 	return r, nA, nB


### PR DESCRIPTION
This add's support for a conf field to the ring and as well as to ring nodes. The sample ring cmd only supports loading a provided file into the bytes. Config values are only shown for nodes if the `fullnode` arguments is passed:

```
fhines@47:~/go/src/github.com/gholt/ring/ring (confstore)$ go run main.go /tmp/ort.builder fullnodes
ID:        731a6b46efebe15b
Active:    true
Capacity:  1000
Tiers:     server1
           z1
Addresses: 127.0.0.1:8001
           127.0.0.2:8001
Meta:      onmetalv1
Conf:

ID:        0541696d282bea38
Active:    true
Capacity:  1000
Tiers:     server2
           z2
Addresses: 127.0.0.1:8002
           127.0.0.2:8002
Meta:      onmetalv1
Conf:      {
               watwat
           }


ID:        90c206788d51c426
Active:    true
Capacity:  1000
Tiers:     server3
           z3
Addresses: 127.0.0.1:8003
           127.0.0.2:8003
Meta:      othermeta
Conf:      {"test": "stuff"}
``` 

The config bytes set for the top level is only dumped/shown if called with the new ring `print-config` command:

```
fhines@47:~/go/src/github.com/gholt/ring/ring (confstore)$ go run main.go /tmp/ort.builder print-config
{
    watwat
}
```

This pull also includes some minor bugfixes:

- The ring cmd create command now actually uses the arguments passed to it.
- The ring cmd create command now throws an error if an invalid argument is passed to it rather than ignoring it.
- The ring cmd node set/add command now throws an error if an invalid argument is passed to it.