### PR TITLE
Allow shutting down the tcp msg ring

### DIFF
--- a/tcp_msg_ring.go
+++ b/tcp_msg_ring.go
@@ -340,7 +340,6 @@ func (m *TCPMsgRing) Listen() error {
 		go func() {
 			m.handshake(conn)
 			go m.handleForever(conn)
-			//m.wg.Add(1)
 		}()
 	}
 }


### PR DESCRIPTION
Adding a Stop() call to the tcp message ring implementation to provide clean shutdowns