### PR TITLE
Start using Ring/Builder format versions

### DIFF
--- a/builder.go
+++ b/builder.go
@@ -10,6 +10,9 @@ import (
 )
 
 const (
+	// BUILDERVERSION is the builder file format version written to and checked
+	// for in the builder file header. If the on disk format of the builder changes
+	// this version should be incremented.
 	BUILDERVERSION = "RINGBUILDERv0001"
 )
 

--- a/builder.go
+++ b/builder.go
@@ -9,6 +9,10 @@ import (
 	"time"
 )
 
+const (
+	BUILDERVERSION = "RINGBUILDERv0001"
+)
+
 // Builder is used to construct Rings over time. Rings are the immutable state
 // of a Builder's assignments at a given point in time.
 type Builder struct {
@@ -70,7 +74,7 @@ func LoadBuilder(r io.Reader) (*Builder, error) {
 	if err != nil {
 		return nil, err
 	}
-	if string(header) != "RINGBUILDERv0001" {
+	if string(header) != BUILDERVERSION {
 		return nil, fmt.Errorf("unknown header %s", string(header))
 	}
 	b := &Builder{}
@@ -256,7 +260,7 @@ func (b *Builder) Persist(w io.Writer) error {
 	// binary.Put* calls instead.
 	gw := gzip.NewWriter(w)
 	defer gw.Close() // does not close the underlying writer
-	_, err := gw.Write([]byte("RINGBUILDERv0001"))
+	_, err := gw.Write([]byte(BUILDERVERSION))
 	if err != nil {
 		return err
 	}

--- a/ring.go
+++ b/ring.go
@@ -15,6 +15,10 @@ import (
 	"math"
 )
 
+const (
+	RINGVERSION = "RINGv00000000001"
+)
+
 // Ring is the immutable snapshot of data assignments to nodes.
 type Ring interface {
 	// Version is the time.Now().UnixNano() of when the Ring data was
@@ -90,7 +94,7 @@ func LoadRing(rd io.Reader) (Ring, error) {
 	if err != nil {
 		return nil, err
 	}
-	if string(header) != "RINGv00000000001" {
+	if string(header) != RINGVERSION {
 		return nil, fmt.Errorf("unknown header %s", string(header))
 	}
 	r := &ring{}
@@ -240,7 +244,7 @@ func (r *ring) Persist(w io.Writer) error {
 	// binary.Put* calls instead.
 	gw := gzip.NewWriter(w)
 	defer gw.Close() // does not close the underlying writer
-	_, err := gw.Write([]byte("RINGv00000000001"))
+	_, err := gw.Write([]byte(RINGVERSION))
 	if err != nil {
 		return err
 	}

--- a/ring.go
+++ b/ring.go
@@ -16,6 +16,9 @@ import (
 )
 
 const (
+	// RINGVERSION is the ring file format version written to and checked
+	// for in the ring file header. If the on disk format of the ring changes
+	// this version should be incremented.
 	RINGVERSION = "RINGv00000000001"
 )
 

--- a/utils.go
+++ b/utils.go
@@ -2,6 +2,7 @@ package ring
 
 import (
 	"compress/gzip"
+	"fmt"
 	"io"
 	"io/ioutil"
 	"os"
@@ -27,12 +28,18 @@ func RingOrBuilder(fileName string) (Ring, *Builder, error) {
 		return r, b, err
 	}
 	if string(header[:5]) == "RINGv" {
+		if string(header[:16]) != RINGVERSION {
+			return r, b, fmt.Errorf("Ring Version missmatch, expected %s found %s", RINGVERSION, header[:16])
+		}
 		gf.Close()
 		if _, err = f.Seek(0, 0); err != nil {
 			return r, b, err
 		}
 		r, err = LoadRing(f)
 	} else if string(header[:12]) == "RINGBUILDERv" {
+		if string(header[:16]) != BUILDERVERSION {
+			return r, b, fmt.Errorf("Builder Version missmatch, expected %s found %s", BUILDERVERSION, header[:16])
+		}
 		gf.Close()
 		if _, err = f.Seek(0, 0); err != nil {
 			return r, b, err


### PR DESCRIPTION
This adds two constants called BUILDERVERSION and RINGVERSION that contain the current builder/ring on disk version and is used when the headers are written out. LoadRingOrBuilder also now checks to make sure that Version it expects and of the file its attempting load actually match.